### PR TITLE
Solves bug when reporting AuthenticationFailed.

### DIFF
--- a/zign/api.py
+++ b/zign/api.py
@@ -126,7 +126,7 @@ def get_named_token(scope, realm, name, user, password, url=None,
             break
         except AuthenticationFailed as e:
             if prompt:
-                error(e)
+                error(str(e))
                 info('Please check your username and password and try again.')
                 password = None
             else:


### PR DESCRIPTION
Before fix, as I login with wrong credentials:

$ ./venv-3.4/bin/zign token
Password for pfigue: invalidPassword
Traceback (most recent call last):
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/zign/api.py", line 115, in get_named_token
    result = get_new_token(realm, scope, user, password, url=url, insecure=insecure)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/zign/api.py", line 57, in get_new_token
    raise AuthenticationFailed('Token Service returned {}'.format(response.text))
zign.api.AuthenticationFailed: Authentication failed: Token Service returned {"code":401,"message":"ERROR sendRequest(): {\"error\":\"invalid_grant\",\"error_description\":\"The provided access grant is invalid, expired, or revoked.\"}\n","reason":"Unauthorized"}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./venv-3.4/bin/zign", line 9, in <module>
    load_entry_point('stups-zign==0.17', 'console_scripts', 'zign')()
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/zign/cli.py", line 108, in main
    cli()
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/core.py", line 700, in **call**
    return self.main(_args, *_kwargs)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/core.py", line 680, in main
    rv = self.invoke(ctx)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/core.py", line 1027, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/core.py", line 873, in invoke
    return ctx.invoke(self.callback, *_ctx.params)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/core.py", line 508, in invoke
    return callback(_args, *_kwargs)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context().obj, *args, *_kwargs)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/zign/cli.py", line 99, in token
    token = get_named_token(scope, realm, name, user, password, url, insecure, refresh, prompt=True)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/zign/api.py", line 119, in get_named_token
    error(e)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/clickclick/console.py", line 49, in error
    secho(msg, fg='red', bold=True, *_kwargs)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/clickclick/console.py", line 37, in secho
    click.secho(_args, *_kwargs)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/termui.py", line 417, in secho
    return echo(style(text, *_styles), file=file, nl=nl, err=err, color=color)
  File "/home/pfigue/Workspace/playing-with-stups/venv-3.4/lib/python3.4/site-packages/click/termui.py", line 390, in style
    return ''.join(bits)
TypeError: sequence item 2: expected str instance, AuthenticationFailed found

After fix:

$ ./venv-3.4/bin/zign token
Password for pfigue: invalidPassword
Authentication failed: Token Service returned {"code":401,"message":"ERROR sendRequest(): {\"error\":\"invalid_grant\",\"error_description\":\"The provided access grant is invalid, expired, or revoked.\"}\n","reason":"Unauthorized"}
Please check your username and password and try again.
Password for pfigue: 
Aborted!
