### PR TITLE
backwards compatible get_config()

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -97,3 +97,11 @@ def test_get_named_token_services(monkeypatch):
     monkeypatch.setattr('tokens.get', lambda x: 'svcmytok123')
     tok = zign.api.get_named_token(scope=['myscope'], realm=None, name='mytok', user='myusr', password='mypw')
     assert tok['access_token'] == 'svcmytok123'
+
+
+def test_backwards_compatible_get_config(monkeypatch):
+    load_config = MagicMock()
+    load_config.return_value = {'url': 'http://localhost'}
+    monkeypatch.setattr('stups_cli.config.load_config', load_config)
+    assert {'url': 'http://localhost'} == zign.api.get_config()
+    load_config.assert_called_with('zign')

--- a/zign/config.py
+++ b/zign/config.py
@@ -2,6 +2,7 @@ import os
 import click
 
 KEYRING_KEY = 'zign'
+OLD_CONFIG_NAME = 'zign'
 CONFIG_NAME = 'zalando-token-cli'
 CONFIG_DIR_PATH = click.get_app_dir(CONFIG_NAME)
 TOKENS_FILE_PATH = os.path.join(CONFIG_DIR_PATH, 'tokens.yaml')


### PR DESCRIPTION
Piu uses `get_config()` without parameters, this should use the old config...