### PR TITLE
Implicit flow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 clickclick>=1.0
 keyring
 keyrings.alt
-oauth2client>=4.0.0
 PyYAML
 requests
 stups-tokens

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 clickclick>=1.0
-keyring
-keyrings.alt
 PyYAML
 requests
 stups-tokens

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,11 +96,13 @@ def test_backwards_compatible_get_config(monkeypatch):
 
 def test_token_implicit_flow(monkeypatch):
 
+    access_token = 'myacctok'
+
     def webbrowser_open(url, **kwargs):
-        pass
+        assert url == 'https://localhost/authorize?business_partner_id=123&client_id=foobar&redirect_uri=http://localhost:8081&response_type=token'
 
     server = MagicMock()
-    server.return_value.query_params = {'access_token': 'mytok', 'refresh_token': 'foo', 'expires_in': 3600}
+    server.return_value.query_params = {'access_token': access_token, 'refresh_token': 'foo', 'expires_in': 3600, 'token_type': 'Bearer'}
 
     load_config = MagicMock()
     load_config.return_value = {'authorize_url': 'https://localhost/authorize', 'token_url': 'https://localhost/token', 'client_id': 'foobar', 'business_partner_id': '123'}
@@ -109,3 +111,4 @@ def test_token_implicit_flow(monkeypatch):
     monkeypatch.setattr('webbrowser.open', webbrowser_open)
     monkeypatch.setattr('zign.api.ClientRedirectServer', server)
     token = zign.api.get_token_implicit_flow('test_token_implicit_flow')
+    assert access_token == token['access_token']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,12 +100,12 @@ def test_token_implicit_flow(monkeypatch):
         pass
 
     server = MagicMock()
-    server.return_value.query_params = {'access_token': 'mytok'}
+    server.return_value.query_params = {'access_token': 'mytok', 'refresh_token': 'foo', 'expires_in': 3600}
 
     load_config = MagicMock()
     load_config.return_value = {'authorize_url': 'https://localhost/authorize', 'token_url': 'https://localhost/token', 'client_id': 'foobar', 'business_partner_id': '123'}
     monkeypatch.setattr('stups_cli.config.load_config', load_config)
     monkeypatch.setattr('zign.api.load_config_ztoken', lambda x: {})
     monkeypatch.setattr('webbrowser.open', webbrowser_open)
-    monkeypatch.setattr('zign.oauth2.ClientRedirectServer', server)
+    monkeypatch.setattr('zign.api.ClientRedirectServer', server)
     token = zign.api.get_token_implicit_flow('test_token_implicit_flow')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,10 +16,13 @@ def test_is_valid():
 
 
 def test_get_named_token_deprecated(monkeypatch):
+    logger = MagicMock()
     response = MagicMock(status_code=401)
     monkeypatch.setattr('zign.api.get_token', lambda x, y: 'mytok701')
+    monkeypatch.setattr('zign.api.logger', logger)
     token = zign.api.get_named_token('myrealm', ['myscope'], 'myuser', 'mypass', 'http://example.org')
     assert 'mytok701' == token['access_token']
+    logger.warning.assert_called_with('"get_named_token" is deprecated, please use "zign.api.get_token" instead')
 
 
 def test_get_new_token_server_error(monkeypatch):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,14 +15,11 @@ def test_is_valid():
     assert not zign.api.is_valid({'creation_time': now - 3480, 'expires_in': 3600})
 
 
-def test_get_new_token_auth_fail(monkeypatch):
+def test_get_named_token_deprecated(monkeypatch):
     response = MagicMock(status_code=401)
-    monkeypatch.setattr('requests.get', MagicMock(return_value=response))
-    monkeypatch.setattr('stups_cli.config.store_config', lambda x, y: None)
-    with pytest.raises(zign.api.AuthenticationFailed) as excinfo:
-        zign.api.get_named_token('myrealm', ['myscope'], 'myuser', 'mypass', 'http://example.org')
-
-    assert 'Authentication failed: Token Service' in str(excinfo)
+    monkeypatch.setattr('zign.api.get_token', lambda x, y: 'mytok701')
+    token = zign.api.get_named_token('myrealm', ['myscope'], 'myuser', 'mypass', 'http://example.org')
+    assert 'mytok701' == token['access_token']
 
 
 def test_get_new_token_server_error(monkeypatch):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,6 +91,28 @@ def test_backwards_compatible_get_config(monkeypatch):
     load_config.assert_called_with('zign')
 
 
+def test_get_config(monkeypatch):
+    load_config = MagicMock()
+    load_config.return_value = {}
+    store_config = MagicMock()
+    def prompt(message, **kwargs):
+        # just return the prompt text for easy assertion
+        return message
+    monkeypatch.setattr('stups_cli.config.load_config', load_config)
+    monkeypatch.setattr('stups_cli.config.store_config', store_config)
+    monkeypatch.setattr('click.prompt', prompt)
+    monkeypatch.setattr('requests.get', lambda x, timeout: None)
+    config = zign.api.get_config(zign.config.CONFIG_NAME)
+    expected_config = {
+        'authorize_url': 'Please enter the OAuth 2 Authorization Endpoint URL',
+        'business_partner_id': 'Please enter the Business Partner ID',
+        'client_id': 'Please enter the OAuth 2 Client ID',
+        'token_url': 'Please enter the OAuth 2 Token Endpoint URL'
+    }
+    assert config == expected_config
+
+
+
 def test_token_implicit_flow(monkeypatch):
 
     access_token = 'myacctok'

--- a/tests/test_cli_zign.py
+++ b/tests/test_cli_zign.py
@@ -7,19 +7,12 @@ from zign.cli_zign import cli_zign
 def test_create_list_delete(monkeypatch):
     token = 'abc-123'
 
-    response = MagicMock()
-    response.status_code = 200
-    response.json.return_value = {'access_token': token}
-
-    monkeypatch.setattr('keyring.set_password', MagicMock())
-    monkeypatch.setattr('requests.get', MagicMock(return_value=response))
-    monkeypatch.setattr('stups_cli.config.store_config', MagicMock())
+    monkeypatch.setattr('zign.api.perform_implicit_flow', lambda a: {'access_token': token, 'expires_in': 1, 'token_type': 'test'})
 
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli_zign, ['token', '-n', 'mytok', '--password', 'mypass'], catch_exceptions=False,
-                               input='localhost\n')
+        result = runner.invoke(cli_zign, ['token', '-n', 'mytok', '--password', 'mypass'], catch_exceptions=False)
 
         assert token == result.output.rstrip().split('\n')[-1]
 
@@ -35,96 +28,3 @@ def test_create_list_delete(monkeypatch):
 
         # should work again for already deleted tokens
         result = runner.invoke(cli_zign, ['delete', 'mytok'], catch_exceptions=False)
-
-
-def test_empty_config(monkeypatch):
-    token = 'abc-123'
-
-    response = MagicMock()
-    response.status_code = 200
-    response.json.return_value = {'access_token': token}
-
-    monkeypatch.setattr('keyring.set_password', MagicMock())
-    monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
-    monkeypatch.setattr('stups_cli.config.store_config', lambda x, y: None)
-    monkeypatch.setattr('requests.get', MagicMock(return_value=response))
-
-    runner = CliRunner()
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli_zign, ['token', '-n', 'mytok', '--password', 'mypass'], catch_exceptions=False,
-                               input='localhost\n')
-        assert token == result.output.rstrip().split('\n')[-1]
-
-
-def test_auth_failure(monkeypatch):
-    token = 'abc-123'
-
-    def get(url, auth, **kwargs):
-        response = MagicMock()
-        if auth[1] == 'correctpass':
-            response.status_code = 200
-            response.json.return_value = {'access_token': token}
-        else:
-            response.status_code = 401
-        return response
-
-    monkeypatch.setattr('keyring.set_password', MagicMock())
-    monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'http://localhost'})
-    monkeypatch.setattr('stups_cli.config.store_config', lambda x, y: None)
-    monkeypatch.setattr('requests.get', get)
-
-    runner = CliRunner()
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli_zign, ['token', '-n', 'mytok', '-U', 'myusr', '--password', 'mypass'],
-                               catch_exceptions=False, input='wrongpw\ncorrectpass\n')
-        assert 'Authentication failed: Token Service returned ' in result.output
-        assert 'Please check your username and password and try again.' in result.output
-        assert 'Password for myusr: ' in result.output
-        assert token == result.output.rstrip().split('\n')[-1]
-
-
-def test_server_error(monkeypatch):
-    def get(url, **kwargs):
-        response = MagicMock()
-        response.status_code = 503
-        return response
-
-    monkeypatch.setattr('keyring.set_password', MagicMock())
-    monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'http://localhost'})
-    monkeypatch.setattr('stups_cli.config.store_config', lambda x, y: None)
-    monkeypatch.setattr('requests.get', get)
-
-    runner = CliRunner()
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli_zign, ['token', '-n', 'mytok', '-U', 'myusr', '--password', 'mypass'],
-                               catch_exceptions=False)
-        assert 'Server error: Token Service returned HTTP status 503' in result.output
-
-
-def test_user_config(monkeypatch):
-    token = 'abc-123'
-
-    response = MagicMock()
-    response.status_code = 200
-    response.json.return_value = {'access_token': token}
-
-    def get_token(url, auth, **kwargs):
-        assert url == 'https://localhost/access_token'
-        user, passwd = auth
-        assert user == 'jdoe'
-        return response
-
-    monkeypatch.setattr('keyring.set_password', MagicMock())
-    monkeypatch.setattr('stups_cli.config.load_config',
-                        lambda x: {'user': 'jdoe', 'url': 'https://localhost/access_token'})
-    monkeypatch.setattr('stups_cli.config.store_config', lambda x, y: None)
-    monkeypatch.setattr('requests.get', get_token)
-
-    runner = CliRunner()
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli_zign, ['token', '-n', 'mytok', '--password', 'mypass'], catch_exceptions=False)
-        assert token == result.output.rstrip().split('\n')[-1]

--- a/zign/api.py
+++ b/zign/api.py
@@ -1,5 +1,6 @@
 import click
 from clickclick import error, info, UrlType
+import logging
 import os
 import stups_cli.config
 import time
@@ -17,6 +18,8 @@ from urllib.parse import urlparse
 from urllib.parse import urlunsplit
 
 TOKEN_MINIMUM_VALIDITY_SECONDS = 60*5  # 5 minutes
+
+logger = logging.getLogger('zign.api')
 
 
 class ServerError(Exception):
@@ -96,7 +99,7 @@ def load_config_ztoken(config_file: str):
 
 
 def get_new_token(realm: str, scope: list, user, password, url=None, insecure=False):
-    '''"get_new_token" is deprecated, please use "zign.api.get_token" instead'''
+    logger.warning('"get_new_token" is deprecated, please use "zign.api.get_token" instead')
 
     if not url:
         config = get_config(OLD_CONFIG_NAME)
@@ -270,10 +273,8 @@ def get_token_implicit_flow(name=None, authorize_url=None, token_url=None, clien
 
 def get_named_token(scope, realm, name, user, password, url=None,
                     insecure=False, refresh=False, use_keyring=True, prompt=False):
-    '''get named access token, return existing if still valid
-
-    "get_named_token" is deprecated, please use "zign.api.get_token" instead
-    '''
+    '''get named access token, return existing if still valid'''
+    logger.warning('"get_named_token" is deprecated, please use "zign.api.get_token" instead')
 
     access_token = get_token(name, scope)
     return {'access_token': access_token}

--- a/zign/api.py
+++ b/zign/api.py
@@ -96,6 +96,8 @@ def load_config_ztoken(config_file: str):
 
 
 def get_new_token(realm: str, scope: list, user, password, url=None, insecure=False):
+    '''"get_new_token" is deprecated, please use "zign.api.get_token" instead'''
+
     if not url:
         config = get_config(OLD_CONFIG_NAME)
         url = config.get('url')
@@ -268,9 +270,10 @@ def get_token_implicit_flow(name=None, authorize_url=None, token_url=None, clien
 
 def get_named_token(scope, realm, name, user, password, url=None,
                     insecure=False, refresh=False, use_keyring=True, prompt=False):
-    '''get named access token, return existing if still valid'''
-    import warnings
-    warnings.warn('"get_named_token" is deprecated, please use "zign.api.get_token" instead', DeprecationWarning)
+    '''get named access token, return existing if still valid
+
+    "get_named_token" is deprecated, please use "zign.api.get_token" instead
+    '''
 
     access_token = get_token(name, scope)
     return {'access_token': access_token}

--- a/zign/api.py
+++ b/zign/api.py
@@ -212,7 +212,7 @@ def get_token_implicit_flow(name=None, authorize_url=None, token_url=None, clien
                   'client_id':              config['client_id'],
                   'redirect_uri':           'http://localhost:{}'.format(port_number)}
 
-        param_list = ['{}={}'.format(key, params[key]) for key in params]
+        param_list = ['{}={}'.format(key, value) for key, value in sorted(params.items())]
         param_string = '&'.join(param_list)
         parsed_authorize_url = urlparse(config['authorize_url'])
         browser_url = urlunsplit((parsed_authorize_url.scheme, parsed_authorize_url.netloc, parsed_authorize_url.path,
@@ -242,10 +242,10 @@ def get_token_implicit_flow(name=None, authorize_url=None, token_url=None, clien
         httpd.handle_request()
 
     if 'access_token' in httpd.query_params:
-        token = {'access_token':    httpd.query_params['access_token'][0],
-                 'refresh_token':   httpd.query_params['refresh_token'][0],
-                 'expires_in':      int(httpd.query_params['expires_in'][0]),
-                 'token_type':      httpd.query_params['token_type'][0],
+        token = {'access_token':    httpd.query_params['access_token'],
+                 'refresh_token':   httpd.query_params['refresh_token'],
+                 'expires_in':      int(httpd.query_params['expires_in']),
+                 'token_type':      httpd.query_params['token_type'],
                  'scope':           ''}
 
         store_config_ztoken({'refresh_token': token['refresh_token']}, REFRESH_TOKEN_FILE_PATH)

--- a/zign/api.py
+++ b/zign/api.py
@@ -355,6 +355,7 @@ def get_token(name: str, scopes: list):
     if access_token:
         return access_token
 
+    # TODO: support scopes for implicit flow
     token = get_token_implicit_flow(name)
     if token:
         return token['access_token']

--- a/zign/oauth2.py
+++ b/zign/oauth2.py
@@ -97,7 +97,10 @@ class ClientRedirectHandler(BaseHTTPRequestHandler):
         if not query_string:
             self.wfile.write(EXTRACT_TOKEN_PAGE.format(port=self.server.server_port).encode('utf-8'))
         else:
-            self.server.query_params = parse_qs(query_string)
+            query_params = {}
+            for key, val in parse_qs(query_string).items():
+                query_params[key] = val[0]
+            self.server.query_params = query_params
             if 'access_token' in self.server.query_params:
                 page = SUCCESS_PAGE
             else:

--- a/zign/oauth2.py
+++ b/zign/oauth2.py
@@ -1,0 +1,120 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+SUCCESS_PAGE = '''<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <title>Authentication Successful - Zign</title>
+    <style>
+        body {
+            font-family: sans-serif;
+        }
+    </style>
+  </head>
+  <body>
+    <p>You are now authenticated with Zign.</p>
+    <p>The authentication flow has completed. You may close this window.</p>
+  </body>
+</html>'''
+
+EXTRACT_TOKEN_PAGE = '''<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <title>Redirecting...</title>
+    <style>
+        body {{
+            font-family: sans-serif;
+        }}
+        #error {{
+            color: red;
+        }}
+    </style>
+    <script>
+        (function extractFragmentQueryString() {{
+            function displayError(message) {{
+              var errorElement = document.getElementById("error");
+              errorElement.textContent = message || "Unknown error";
+            }}
+
+            function parseQueryString(qs) {{
+                return qs.split("&")
+                        .reduce(function (result, param) {{
+                          var split = param.split("=");
+                          if (split.length === 2) {{
+                            var key = decodeURIComponent(split[0]);
+                            var val = decodeURIComponent(split[1]);
+                            result[key] = val;
+                          }}
+                          return result;
+                        }}, {{}});
+            }}
+            var query = window.location.hash.substring(1);
+            var params = parseQueryString(query);
+            if (params.access_token) {{
+                window.location.href = "http://localhost:{port}/?" + query;
+            }} else {{
+                displayError("Error: No access_token in URL.")
+            }}
+        }})();
+    </script>
+  </head>
+  <body>
+    <noscript>
+        <p>Your browser does not support Javascript! Please enable it or switch to a Javascript enabled browser.</p>
+    </noscript>
+    <p>Redirecting...</p>
+    <p id="error"></p>
+  </body>
+</html>'''
+
+ERROR_PAGE = '''<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <title>Authentication Failed - Zign</title>
+  </head>
+  <body>
+    <p><font face=arial>The authentication flow did not complete successfully. Please try again. You may close this
+    window.</font></p>
+  </body>
+</html>'''
+
+
+class ClientRedirectHandler(BaseHTTPRequestHandler):
+    '''Handles OAuth 2.0 redirect and return a success page if the flow has completed.'''
+
+    def do_GET(self):
+        '''Handle the GET request from the redirect.
+
+        Parses the token from the query parameters and returns a success page if the flow has completed'''
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        query_string = urlparse(self.path).query
+
+        if not query_string:
+            self.wfile.write(EXTRACT_TOKEN_PAGE.format(port=self.server.server_port).encode('utf-8'))
+        else:
+            self.server.query_params = parse_qs(query_string)
+            if 'access_token' in self.server.query_params:
+                page = SUCCESS_PAGE
+            else:
+                page = ERROR_PAGE
+            self.wfile.write(page.encode('utf-8'))
+
+    def log_message(self, format, *args):
+        """Do not log messages to stdout while running as cmd. line program."""
+
+
+class ClientRedirectServer(HTTPServer):
+    """A server to handle OAuth 2.0 redirects back to localhost.
+
+    Waits for a single request and parses the query parameters
+    into query_params and then stops serving.
+    """
+    query_params = {}
+
+    def __init__(self, address):
+        super().__init__(address, ClientRedirectHandler)


### PR DESCRIPTION
Fixes #40 

Also fixes #25 

All other CLI tools should only call `zign.api.get_token`, all other functions are deprecated (or internal).