### PR TITLE
Fix retries for ports that are in use (closes #38)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ class PyTest(TestCommand):
     def run_tests(self):
         try:
             import pytest
-        except:
+        except ImportError:
             raise RuntimeError('py.test is not installed, run: pip install pytest')
         params = {'args': self.test_args}
         if self.cov:

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -1,0 +1,10 @@
+import pytest
+import socket
+import zign.oauth2
+
+
+def test_raises_on_used_port():
+    server1 = zign.oauth2.ClientRedirectServer(('localhost', 8081))
+
+    with pytest.raises(socket.error):
+        server2 = zign.oauth2.ClientRedirectServer(('localhost', 8081))

--- a/zign/api.py
+++ b/zign/api.py
@@ -89,7 +89,7 @@ def load_config_ztoken(config_file: str):
     try:
         with open(config_file) as fd:
             data = yaml.safe_load(fd)
-    except:
+    except FileNotFoundError:
         data = None
     return data or {}
 
@@ -112,7 +112,7 @@ def get_new_token(realm: str, scope: list, user, password, url=None, insecure=Fa
         raise ServerError('Token Service returned HTTP status {}: {}'.format(response.status_code, response.text))
     try:
         json_data = response.json()
-    except:
+    except:  # noqa: E731,E123
         raise ServerError('Token Service returned invalid JSON data')
 
     if not json_data.get('access_token'):
@@ -157,7 +157,7 @@ def perform_implicit_flow(config: dict):
     while True:
         try:
             httpd = ClientRedirectServer(('127.0.0.1', port_number))
-        except socket.error as e:
+        except socket.error:
             if port_number > max_port_number:
                 success = False
                 break

--- a/zign/cli.py
+++ b/zign/cli.py
@@ -67,10 +67,8 @@ def delete_token(obj, name):
     '''Delete a named token'''
     data = get_tokens()
 
-    try:
+    if data and name in data:
         del data[name]
-    except:
-        pass
 
     with open(TOKENS_FILE_PATH, 'w') as fd:
         yaml.safe_dump(data, fd)

--- a/zign/oauth2.py
+++ b/zign/oauth2.py
@@ -118,5 +118,8 @@ class ClientRedirectServer(HTTPServer):
     """
     query_params = {}
 
+    # Raise an error if the provided address is already in use
+    allow_reuse_address = False
+
     def __init__(self, address):
         super().__init__(address, ClientRedirectHandler)


### PR DESCRIPTION
Fixes: #38 

Previously, no exception was thrown if the server port was already in
use. Therefore, the port assignment code in `zign.api` did not work as
expected.

Disallowing address re-use in `zign.oauth2.ClientRedirectServer` fixes
this behavior.

Additional changes:

- Fix or ignore flake8 issues
- Add test for zign.oauth2 module